### PR TITLE
Add new tag 9F0A

### DIFF
--- a/src/main/java/io/github/binaryfoo/EmvTags.java
+++ b/src/main/java/io/github/binaryfoo/EmvTags.java
@@ -92,6 +92,7 @@ public class EmvTags {
   public static final Tag CDOL_2 = fromHex("8D");
   public static final Tag APPLICATION_USAGE_CONTROL = fromHex("9F07");
   public static final Tag CARD_APPLICATION_VERSION_NUMBER = fromHex("9F08");
+  public static final Tag APPLICATION_SELECTION_REGISTERED_PROPRIETARY_DATA = fromHex("9F0A");
   public static final Tag IAC_DEFAULT = fromHex("9F0D");
   public static final Tag IAC_DENIAL = fromHex("9F0E");
   public static final Tag IAC_ONLINE = fromHex("9F0F");


### PR DESCRIPTION
Few years ago European Payment Council defined a new data element - tag 9F0A. This PR adds the tag to EmvTags enum.

https://ims.ul.com/electronic-card-identifier-one-more-step-mif-compliance

https://www.europeanpaymentscouncil.eu/sites/default/files/KB/files/EPC050-16%20SCS%20Volume%207%201%20-%20Bul%2001%20-%2020160229%20-%20Book%202%20-%20EEA%20Product%20Identification%20and%20usage%20in%20Selection%20of%20Application.pdf