### PR TITLE
Fix for German country code

### DIFF
--- a/src/main/resources/numeric-country-list.csv
+++ b/src/main/resources/numeric-country-list.csv
@@ -79,7 +79,7 @@
 266, GAB (Gabon)
 270, GMB (Gambia)
 268, GEO (Georgia)
-276, DEU (Germany)
+280, DEU (Germany)
 288, GHA (Ghana)
 292, GIB (Gibraltar)
 300, GRC (Greece)


### PR DESCRIPTION
German banking systems still use the ISO code 280 (former code for West Germany).
The current ISO code for Germany, 276, is not used in the financial world.

The official documents are in German, but here is a translated announcement of Germans popular local debit card scheme Girocard as reference:
https://www.girocard.eu/media/weiternutzung_iso3166-code-280_deutschland.pdf
Quote from the document: "There are no plans to replace Code 280 as representation for Germany"