### PR TITLE
Bump snakeyaml from 1.16 to 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.16</version>
+      <version>2.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/io/github/binaryfoo/TagMetaData.kt
+++ b/src/main/java/io/github/binaryfoo/TagMetaData.kt
@@ -5,6 +5,7 @@ import io.github.binaryfoo.decoders.PrimitiveDecoder
 import io.github.binaryfoo.res.ClasspathIO
 import io.github.binaryfoo.tlv.Tag
 import org.yaml.snakeyaml.DumperOptions
+import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.Constructor
 import org.yaml.snakeyaml.representer.Representer
@@ -67,7 +68,7 @@ class TagMetaData(private val metadata: MutableMap<String, TagInfo>) {
 
     @JvmStatic
     fun load(name: String): TagMetaData {
-      val yaml = Yaml(Constructor(), Representer(), DumperOptions(), object : Resolver() {
+      val yaml = Yaml(Constructor(LoaderOptions()), Representer(DumperOptions()), DumperOptions(), object : Resolver() {
         override fun addImplicitResolvers() {
           // leave everything as strings
         }


### PR DESCRIPTION
# Overview
Bumps [snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml) from 1.16 to 2.2.
Also, a compile error that occurred as a result of this change has been corrected.

# Background

https://github.com/binaryfoo/emv-bertlv/issues/21